### PR TITLE
journey to test migration in public facing bits of action

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ jobs:
   deployment. A mabl plan is a collection of similarly configured tests.
 - `plans_failed` {int32} - number of mabl plans that failed against this
   deployment. A mabl plan is a collection of similarly configured tests.
-- `journeys_run` {int32} - total number of mabl journeys run against this
-  deployment. A mabl journey is an end to end test of your application.
-- `journeys_passed` {int32} - number of mabl journeys that passed against this
-  deployment. A mabl journey is an end to end test of your application.
-- `journeys_failed` {int32} - number of mabl journeys that failed against this
-  deployment. A mabl journey is an end to end test of your application.
+- `tests_run` {int32} - total number of mabl tests run against this deployment.
+- `tests_passed` {int32} - number of mabl tests that passed against this
+  deployment.
+- `tests_failed` {int32} - number of mabl tests that failed against this
+  deployment.

--- a/action.yml
+++ b/action.yml
@@ -55,12 +55,12 @@ outputs:
     description: "number of mabl plans that passed against this deployment.  A mabl plan is a collection of similarly configured tests."
   plans_failed:
     description: "number of mabl plans that failed against this deployment.  A mabl plan is a collection of similarly configured tests."
-  journeys_run:
-    description: "total number of mabl journeys run against this deployment.  A mabl journey is an end to end test of your application."
-  journeys_passed:
-    description: "number of mabl journeys that passed against this deployment.  A mabl journey is an end to end test of your application."
-  journeys_failed:
-    description: "number of mabl journeys that failed against this deployment.  A mabl journey is an end to end test of your application."
+  tests_run:
+    description: "total number of mabl tests run against this deployment.  A mabl tests is an end to end test of your application."
+  tests_passed:
+    description: "number of mabl tests that passed against this deployment.  A mabl tests is an end to end test of your application."
+  tests_failed:
+    description: "number of mabl tests that failed against this deployment.  A mabl tests is an end to end test of your application."
 
 runs:
   using: "node12"

--- a/action.yml
+++ b/action.yml
@@ -56,11 +56,11 @@ outputs:
   plans_failed:
     description: "number of mabl plans that failed against this deployment.  A mabl plan is a collection of similarly configured tests."
   tests_run:
-    description: "total number of mabl tests run against this deployment.  A mabl tests is an end to end test of your application."
+    description: "total number of mabl tests run against this deployment."
   tests_passed:
-    description: "number of mabl tests that passed against this deployment.  A mabl tests is an end to end test of your application."
+    description: "number of mabl tests that passed against this deployment."
   tests_failed:
-    description: "number of mabl tests that failed against this deployment.  A mabl tests is an end to end test of your application."
+    description: "number of mabl tests that failed against this deployment."
 
 runs:
   using: "node12"

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,15 +158,15 @@ async function run() {
       '' + finalExecutionResult.plan_execution_metrics.failed,
     );
     core.setOutput(
-      'journeys_run',
+      'tests_run',
       '' + finalExecutionResult.journey_execution_metrics.total,
     );
     core.setOutput(
-      'journeys_passed',
+      'tests_passed',
       '' + finalExecutionResult.journey_execution_metrics.passed,
     );
     core.setOutput(
-      'journeys_failed',
+      'tests_failed',
       '' + finalExecutionResult.journey_execution_metrics.failed,
     );
 
@@ -174,12 +174,12 @@ async function run() {
       core.debug('Deployment plans passed');
     } else if (continueOnPlanFailure) {
       core.warning(
-        `There were ${finalExecutionResult.journey_execution_metrics.failed} journey failures but the continueOnPlanFailure flag is set so the task has been marked as passing`,
+        `There were ${finalExecutionResult.journey_execution_metrics.failed} test failures but the continueOnPlanFailure flag is set so the task has been marked as passing`,
       );
       // core.setNeutral();  Todo  Set neutral when support is added to actions v2
     } else {
       core.setFailed(
-        `${finalExecutionResult.journey_execution_metrics.failed} mabl Journey(s) failed`,
+        `${finalExecutionResult.journey_execution_metrics.failed} mabl test(s) failed`,
       );
     }
   } catch (err) {

--- a/src/table.ts
+++ b/src/table.ts
@@ -25,8 +25,8 @@ export function prettyPrintExecution(execution: Execution) {
     execution.plan.app_href,
   ]);
 
-  let journeyTable = new Table({
-    head: ['Browser', 'Status', 'Journey Name', 'Duration', 'mabl App Link'],
+  let testTable = new Table({
+    head: ['Browser', 'Status', 'Test Name', 'Duration', 'mabl App Link'],
     style: {
       head: [],
       border: [],
@@ -35,20 +35,20 @@ export function prettyPrintExecution(execution: Execution) {
     wordWrap: true,
   }) as HorizontalTable;
   execution.journey_executions.forEach(jE => {
-    let journey: JourneyInfo | undefined = execution.journeys.find(
-      journey => journey.id === jE.journey_id,
+    let test: JourneyInfo | undefined = execution.journeys.find(
+      test => test.id === jE.journey_id,
     );
-    journeyTable.push([
+    testTable.push([
       jE.browser_type,
       jE.success ? 'Passed' : 'Failed',
-      journey ? journey.name : jE.journey_id,
+      test ? test.name : jE.journey_id,
       moment.utc(jE.stop_time - jE.start_time).format('HH:mm:ss'),
       jE.app_href,
     ]);
   });
 
   outputTable(planTable);
-  outputTable(journeyTable);
+  outputTable(testTable);
 }
 
 function outputTable(table: HorizontalTable) {


### PR DESCRIPTION
Migrates form the term journey to the term test for all public facing parts of the action. Some of the inner api calls still refer to journey because not all the apis yet reflect the change.