### PR TITLE
Sha on pull request

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,5 +1,4 @@
-on: [pull-request]
-
+on: [pull_request]
 name: mabl
 
 jobs:

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,0 +1,32 @@
+on: [pull-request]
+
+name: mabl
+
+jobs:
+  test:
+    name: Mabl Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm run check
+
+      - name: Compile Typescript
+        run: npm run build
+
+      - name: Run Tests
+        run: npm test
+
+      - name: Run mabl tests against deployment
+        id: mabl-test-deployment
+        uses: ./
+        env:
+          MABL_API_KEY: ${{ secrets.MABL_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          application-id: l-j3VqIO6lLLOOEoFTPSxA-a
+          environment-id: rtb4kWD5LuTr2KxaHvwfaA-e

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,25 @@
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@actions/core/-/core-1.2.6.tgz",
       "integrity": "sha1-p41J9BpN7xjojOR8LKxhXVaUvwk="
     },
+    "@actions/github": {
+      "version": "4.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@actions/github/-/github-4.0.0.tgz",
+      "integrity": "sha1-1SBIMVGiv10tyc0PIPmsOi5FiBY=",
+      "requires": {
+        "@actions/http-client": "^1.0.8",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.3",
+        "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.9",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@actions/http-client/-/http-client-1.0.9.tgz",
+      "integrity": "sha1-rxlH0CAEPbxqO0xZGIkglcMP+1I=",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -111,6 +130,103 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+      "integrity": "sha1-7jHGmwHQN4wS/T/+QGAw89lNO1Y=",
+      "requires": {
+        "@octokit/types": "^6.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.2.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/core/-/core-3.2.4.tgz",
+      "integrity": "sha1-V5ElYFepYuypcuMYGPAkVIl/0QY=",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.10",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+      "integrity": "sha1-dBzh+i9Pt3zo6+DG6vXOY/Vl+Og=",
+      "requires": {
+        "@octokit/types": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.8",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/graphql/-/graphql-4.5.8.tgz",
+      "integrity": "sha1-1CNzYzwwFdDq/OZKjOGWvhZ/3Zs=",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "2.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/openapi-types/-/openapi-types-2.0.0.tgz",
+      "integrity": "sha1-bY+K2ds7daORFfXe8mVN+L7Tnyg="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.6.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz",
+      "integrity": "sha1-RdE9v1/4rtVPGjcWsdV/3GJyDF8=",
+      "requires": {
+        "@octokit/types": "^6.0.1"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.4.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
+      "integrity": "sha1-EFz5MlVDIVXeB4ye/DO9ThTRzWM=",
+      "requires": {
+        "@octokit/types": "^6.1.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.12",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/request/-/request-5.4.12.tgz",
+      "integrity": "sha1-sEgm+pNGcMVrE1qBRHviwXI6L/w=",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/request-error/-/request-error-2.0.4.tgz",
+      "integrity": "sha1-B91cBSHS7pdSASdMRyoSeRd0EmI=",
+      "requires": {
+        "@octokit/types": "^6.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.1.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@octokit/types/-/types-6.1.1.tgz",
+      "integrity": "sha1-vIiz619EewJaKhqBd6ctshbo1Mo=",
+      "requires": {
+        "@octokit/openapi-types": "^2.0.0",
+        "@types/node": ">= 8"
+      }
+    },
     "@types/async-retry": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.1.tgz",
@@ -147,8 +263,7 @@
     "@types/node": {
       "version": "12.6.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
-      "dev": true
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -340,6 +455,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha1-tsA0h/ROJCAN0wyl5qGXnF0vtjU="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -538,6 +658,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha1-Y2jL20Cr8zc7UlrIfkomDDpwCRk="
     },
     "diff": {
       "version": "4.0.2",
@@ -1197,6 +1322,11 @@
       "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q="
+    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-regex/-/is-regex-1.1.1.tgz",
@@ -1402,6 +1532,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1495,7 +1630,6 @@
       "version": "1.4.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2130,6 +2264,11 @@
         "tslib": "^1.8.1"
       }
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/type-check/-/type-check-0.4.0.tgz",
@@ -2150,6 +2289,11 @@
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/typescript/-/typescript-4.0.3.tgz",
       "integrity": "sha1-FTu9Ro7wdyXB35x36LRT+NNqu6U=",
       "dev": true
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4="
     },
     "uri-js": {
       "version": "4.4.0",
@@ -2278,8 +2422,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "mabl",
   "dependencies": {
     "@actions/core": "^1.2.6",
+    "@actions/github": "^4.0.0",
     "async-retry": "^1.2.3",
     "axios": "^0.20.0",
     "cli-table3": "^0.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,10 @@ async function run(): Promise<void> {
     }
 
     const baseApiUrl = process.env.APP_URL ?? DEFAULT_MABL_APP_URL;
-    const revision = process.env.GITHUB_EVENT_NAME === 'pull_request' ? github.context.payload.pull_request.head.sha : process.env.GITHUB_SHA;
+    const revision =
+      process.env.GITHUB_EVENT_NAME === 'pull_request'
+        ? github.context.payload.pull_request.head.sha
+        : process.env.GITHUB_SHA;
 
     core.info(`Using git revision [${revision}]`);
     core.endGroup();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import {
 import {Application} from './entities/Application';
 import {Execution, ExecutionResult} from './entities/ExecutionResult';
 import {prettyFormatExecution} from './table';
-import * as core from '@actions/core/lib/core';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
 import {Option} from './interfaces';
 
 const DEFAULT_MABL_APP_URL = 'https://app.mabl.com';
@@ -86,7 +87,7 @@ async function run(): Promise<void> {
     }
 
     const baseApiUrl = process.env.APP_URL ?? DEFAULT_MABL_APP_URL;
-    const revision = process.env.GITHUB_SHA;
+    const revision = process.env.GITHUB_EVENT_NAME === 'pull_request' ? github.context.payload.pull_request.head.sha : process.env.GITHUB_SHA;
 
     core.info(`Using git revision [${revision}]`);
     core.endGroup();

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ async function run(): Promise<void> {
     const baseApiUrl = process.env.APP_URL ?? DEFAULT_MABL_APP_URL;
     const revision =
       process.env.GITHUB_EVENT_NAME === 'pull_request'
-        ? github.context.payload.pull_request.head.sha
+        ? github.context.payload.pull_request?.head?.sha
         : process.env.GITHUB_SHA;
 
     core.info(`Using git revision [${revision}]`);


### PR DESCRIPTION
Fixes a bug with how we retrieve the commit SHA for pull_request triggered builds.  GITHUB_SHA refers to the head of the branch github creates to represent the PR, not the head of the branch itself for this action type.

Fixes #29  

pull_request event spec:  https://developer.github.com/webhooks/event-payloads/#pull_request
GITHUB_SHA value for pull_request event trigger:  https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request