### PR TITLE
[IST-90] Version bump page name to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl-github-deployments-action",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "mabl github action for GitHub pipelines integration",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
On creating the Axios fix release, realized the last release was `1.7.0`, but the versions were not bumped. This correctly moves this release to `1.8.0`.