### PR TITLE
[IST-297] Update eslint for glob-parent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
+      "version": "7.12.11",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha1-9K1DWqJj25NbjxDyxVLSP7cWpj8=",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
@@ -312,9 +312,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
+      "version": "7.14.9",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha1-ZlTRcbICT22O4VG/JQlpmRkTHUg=",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -335,12 +335,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
+      "version": "7.14.5",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -378,12 +378,6 @@
           "version": "1.1.3",
           "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
@@ -740,22 +734,38 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha1-fRorI1hVLMBINMCXm9QnU2LjcIU=",
+      "version": "0.4.3",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha1-nkKYHvA1vrPdSa3ResuW6P9vOUw=",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha1-FAeWfUxu7Nc4j4Os8er00Mbljvk=",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha1-h956+cIxgm/daKxyWPd8Qp4OX88=",
+      "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1550,9 +1560,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
+      "version": "5.3.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true
     },
     "acorn-walk": {
@@ -1660,9 +1670,9 @@
       }
     },
     "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+      "version": "2.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
       "dev": true
     },
     "async-retry": {
@@ -2186,9 +2196,9 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "version": "8.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true
     },
     "enquirer": {
@@ -2312,29 +2322,32 @@
       }
     },
     "eslint": {
-      "version": "7.11.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/eslint/-/eslint-7.11.0.tgz",
-      "integrity": "sha1-qvLSOgtfHWUqCO2s6gwZ9/rcCzs=",
+      "version": "7.32.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha1-xtMooUvj+wjI0dIeEsAv23oqgS0=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.0",
-        "esquery": "^1.2.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2342,7 +2355,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -2351,7 +2364,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^5.2.3",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -2360,6 +2373,12 @@
           "version": "5.0.0",
           "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
           "dev": true
         },
         "strip-ansi": {
@@ -2524,19 +2543,19 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.0.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-      "integrity": "sha1-If3I+82ceVzAMh8FY3AglXUVEag=",
+      "version": "2.1.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha1-9lMoJZMFknOSyTjtROsKXJsr0wM=",
       "dev": true
     },
     "espree": {
-      "version": "7.3.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/espree/-/espree-7.3.0.tgz",
-      "integrity": "sha1-3DBDfPZ5R89XYSHr14DxXurHI0g=",
+      "version": "7.3.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha1-8t8zC3Usb1UBn4vYm3ZgA5wbu7Y=",
       "dev": true,
       "requires": {
         "acorn": "^7.4.0",
-        "acorn-jsx": "^5.2.0",
+        "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^1.3.0"
       },
       "dependencies": {
@@ -2555,9 +2574,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
+      "version": "1.4.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -2701,12 +2720,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+      "version": "6.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
@@ -2729,20 +2748,19 @@
       }
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+      "version": "3.0.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha1-YbAzgwKy/p+Vfcwy/CqH8cMEixE=",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
+      "version": "3.2.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha1-ZL/tXLaP48p4s+shStl7Y77c5WE=",
       "dev": true
     },
     "follow-redirects": {
@@ -2825,21 +2843,21 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+      "version": "5.1.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
     },
     "globals": {
-      "version": "12.4.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
+      "version": "13.10.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha1-YLpWw6wsqEXPv0+uynJ62d0gRnY=",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       }
     },
     "graceful-fs": {
@@ -2933,9 +2951,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+      "version": "3.3.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -4692,6 +4710,24 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
@@ -4775,15 +4811,6 @@
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "moment": {
       "version": "2.24.0",
@@ -5284,6 +5311,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.18.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/resolve/-/resolve-1.18.1.tgz",
@@ -5323,9 +5356,9 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "version": "3.0.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -5392,38 +5425,20 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+      "version": "4.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha1-UA6N0P1VsFgVCGJVsxla3ypF/ms=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         }
       }
@@ -5651,41 +5666,67 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/table/-/table-5.4.6.tgz",
-      "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+      "version": "6.7.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/table/-/table-6.7.1.tgz",
+      "integrity": "sha1-7gVZK3FDgxqMlPPO5qrkwczvM+I=",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.6.2",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ajv/-/ajv-8.6.2.tgz",
+          "integrity": "sha1-L7ReDl/LwIEzJsHD2lNdGIG7BXE=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "5.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "version": "4.2.2",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "version": "6.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -5847,9 +5888,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+      "version": "0.20.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -5879,18 +5920,18 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
+      "version": "4.4.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha1-VLw83UMxe8qR413K8wWxpyN950U=",
+      "version": "2.3.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4=",
       "dev": true
     },
     "v8-to-istanbul": {
@@ -6051,15 +6092,6 @@
       "version": "1.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/write/-/write-1.0.3.tgz",
-      "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl-github-deployments-action",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "mabl github action for GitHub pipelines integration",
   "main": "lib/src/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@types/node": "^12.0.10",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
-    "eslint": "^7.11.0",
+    "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^30.7.3",
     "eslint-plugin-no-null": "^1.0.2",


### PR DESCRIPTION
- Updates `eslint` to address CVE-2020-28469 warning about `glob-parent`

Note: point release since this is a testing time dependency and has not effect on Action code/logic. Will push a release so that default branch HEAD and latest release pointer remain in sync.