### PR TITLE
Add a slack notification for a failed deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ jobs:
   the commit being built is associated with any pull requests. This token is
   automatically available as a secret in your repo but must be passed in
   explicitly in order for the action to be able to access it.
+- `SLACK_WEBHOOK_URL` {string} (optional) - Slack incoming webhook URL. When set,
+  the action posts a message to Slack if any mabl tests or plans fail after the
+  deployment completes (including after unexpected task errors once a deployment
+  has been triggered). Includes deployment failure analysis when available
+  (polled for up to 10 attempts). Store as a repository secret.
 
 ### Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,7 @@
 name: "Run mabl tests"
-description: "Register a deployment event with mabl and run associated tests"
+description: >-
+  Register a deployment event with mabl and run associated tests. Set the
+  SLACK_WEBHOOK_URL env var to post Slack notifications when a deployment fails.
 branding:
   icon: play-circle
   color: white

--- a/lib/src/constants.js
+++ b/lib/src/constants.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ActionOutputs = exports.ActionInputs = exports.USER_AGENT = void 0;
+exports.USER_AGENT = 'mabl-github-run-tests-action';
+var ActionInputs;
+(function (ActionInputs) {
+    ActionInputs["ApplicationId"] = "application-id";
+    ActionInputs["BrowserTypes"] = "browser-types";
+    ActionInputs["ContinueOnFailure"] = "continue-on-failure";
+    ActionInputs["EnvironmentId"] = "environment-id";
+    ActionInputs["EventTime"] = "event-time";
+    ActionInputs["HttpHeaders"] = "http-headers";
+    ActionInputs["MablBranch"] = "mabl-branch";
+    ActionInputs["PlanLabels"] = "plan-labels";
+    ActionInputs["RebaselineImages"] = "rebaseline-images";
+    ActionInputs["SetStaticBaseline"] = "set-static-baseline";
+    ActionInputs["Uri"] = "uri";
+    ActionInputs["UrlApi"] = "api-url";
+    ActionInputs["UrlApp"] = "app-url";
+})(ActionInputs || (exports.ActionInputs = ActionInputs = {}));
+var ActionOutputs;
+(function (ActionOutputs) {
+    ActionOutputs["DeploymentId"] = "mabl-deployment-id";
+    ActionOutputs["PlansRun"] = "plans_run";
+    ActionOutputs["PlansPassed"] = "plans_passed";
+    ActionOutputs["PlansFailed"] = "plans_failed";
+    ActionOutputs["TestsRun"] = "tests_run";
+    ActionOutputs["TestsPassed"] = "tests_passed";
+    ActionOutputs["TestsFailed"] = "tests_failed";
+})(ActionOutputs || (exports.ActionOutputs = ActionOutputs = {}));

--- a/lib/src/deploymentAnalysis.js
+++ b/lib/src/deploymentAnalysis.js
@@ -1,0 +1,147 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_MAX_POLL_ATTEMPTS = exports.DEFAULT_POLL_INTERVAL_MS = void 0;
+exports.getDeploymentFailureAnalysisForSlack = getDeploymentFailureAnalysisForSlack;
+exports.formatFailureAnalysisForSlack = formatFailureAnalysisForSlack;
+const axios_1 = __importDefault(require("axios"));
+const core = __importStar(require("@actions/core"));
+const slackUtil_1 = require("./slackUtil");
+exports.DEFAULT_POLL_INTERVAL_MS = 2_000;
+exports.DEFAULT_MAX_POLL_ATTEMPTS = 10;
+const SLACK_ANALYSIS_BODY_MAX_CHARS = 2_700;
+async function getDeploymentFailureAnalysisForSlack(apiClient, workspaceId, deploymentEventId, pollOptions) {
+    const response = await pollForSavedDeploymentFailureAnalysis(apiClient, workspaceId, deploymentEventId, pollOptions);
+    return response?.analysis;
+}
+function formatFailureAnalysisForSlack(analysis) {
+    const synopsis = analysis.synopsis?.trim();
+    const summaryText = analysis.summary_text?.trim();
+    if (!synopsis && !summaryText) {
+        return undefined;
+    }
+    const sections = [];
+    if (synopsis) {
+        sections.push(`*${(0, slackUtil_1.escapeSlackMarkdown)(synopsis)}*`);
+    }
+    if (summaryText) {
+        sections.push((0, slackUtil_1.escapeSlackMarkdown)(summaryText));
+    }
+    return (0, slackUtil_1.fitSlackSectionText)(sections.join('\n\n'), SLACK_ANALYSIS_BODY_MAX_CHARS);
+}
+function getAnalysisFromResponse(response) {
+    if (response.status !== 'done' || !response.analysis) {
+        return undefined;
+    }
+    return response.analysis;
+}
+function formatAnalysisFetchError(error) {
+    if (axios_1.default.isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 403) {
+            return 'HTTP 403 (forbidden — API key may lack analysis permissions)';
+        }
+        if (status !== undefined) {
+            return `HTTP ${status}`;
+        }
+        return error.message;
+    }
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return String(error);
+}
+async function pollForSavedDeploymentFailureAnalysis(apiClient, workspaceId, deploymentEventId, pollOptions) {
+    const maxAttempts = pollOptions?.maxPollAttempts ?? exports.DEFAULT_MAX_POLL_ATTEMPTS;
+    const pollIntervalMs = pollOptions?.pollIntervalMs ?? exports.DEFAULT_POLL_INTERVAL_MS;
+    const sleepFn = pollOptions?.sleep ?? sleep;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            const response = await apiClient.tryGetSavedDeploymentFailureAnalysis(workspaceId, deploymentEventId);
+            if (response === undefined) {
+                if (attempt < maxAttempts) {
+                    if (attempt === 1) {
+                        core.info(`Deployment analysis not ready for event [${deploymentEventId}], polling up to ${maxAttempts} attempt(s)`);
+                    }
+                    await sleepFn(pollIntervalMs);
+                    continue;
+                }
+                core.info(`No deployment analysis for event [${deploymentEventId}] after ${maxAttempts} poll attempt(s)`);
+                return undefined;
+            }
+            const analysis = getAnalysisFromResponse(response);
+            if (analysis) {
+                if (attempt > 1) {
+                    core.info(`Deployment analysis ready for event [${deploymentEventId}] after ${attempt} poll attempt(s)`);
+                }
+                return response;
+            }
+            if (response.status === 'queued' && attempt < maxAttempts) {
+                if (attempt === 1) {
+                    core.info(`Deployment analysis queued for event [${deploymentEventId}], polling up to ${maxAttempts} attempt(s)`);
+                }
+                await sleepFn(pollIntervalMs);
+                continue;
+            }
+            if (response.status === 'queued') {
+                core.info(`Deployment analysis still queued for event [${deploymentEventId}] after ${maxAttempts} poll attempt(s); giving up`);
+            }
+            return undefined;
+        }
+        catch (error) {
+            const message = formatAnalysisFetchError(error);
+            if (axios_1.default.isAxiosError(error) && error.response?.status === 403) {
+                core.warning(`Deployment analysis unavailable for event [${deploymentEventId}]: ${message}`);
+                return undefined;
+            }
+            if (attempt < maxAttempts) {
+                core.warning(`Failed to fetch deployment analysis for event [${deploymentEventId}] (attempt ${attempt}/${maxAttempts}): ${message}`);
+                await sleepFn(pollIntervalMs);
+                continue;
+            }
+            core.warning(`Failed to fetch deployment analysis for event [${deploymentEventId}] after ${maxAttempts} poll attempt(s): ${message}`);
+            return undefined;
+        }
+    }
+    return undefined;
+}
+function sleep(milliseconds) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, milliseconds);
+    });
+}

--- a/lib/src/deploymentFailure.js
+++ b/lib/src/deploymentFailure.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.deploymentHasFailures = deploymentHasFailures;
+exports.formatDeploymentFailureMessage = formatDeploymentFailureMessage;
+exports.formatContinueOnFailureWarning = formatContinueOnFailureWarning;
+function deploymentHasFailures(executionResult) {
+    return (executionResult.journey_execution_metrics.failed > 0 ||
+        executionResult.plan_execution_metrics.failed > 0);
+}
+function formatDeploymentFailureMessage(testsFailed, plansFailed) {
+    const parts = [];
+    if (testsFailed > 0) {
+        parts.push(`${testsFailed} mabl test(s) failed`);
+    }
+    if (plansFailed > 0) {
+        parts.push(`${plansFailed} mabl plan(s) failed`);
+    }
+    if (parts.length === 0) {
+        return 'mabl deployment failed';
+    }
+    return parts.join(' and ');
+}
+function formatContinueOnFailureWarning(testsFailed, plansFailed) {
+    const parts = [];
+    if (testsFailed > 0) {
+        parts.push(`${testsFailed} test failure(s)`);
+    }
+    if (plansFailed > 0) {
+        parts.push(`${plansFailed} plan failure(s)`);
+    }
+    const summary = parts.join(' and ') || 'failures';
+    return `There were ${summary} but the continueOnPlanFailure flag is set so the task has been marked as passing`;
+}

--- a/lib/src/entities/Application.js
+++ b/lib/src/entities/Application.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/entities/Deployment.js
+++ b/lib/src/entities/Deployment.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/entities/Environment.js
+++ b/lib/src/entities/Environment.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/entities/ExecutionResult.js
+++ b/lib/src/entities/ExecutionResult.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/entities/FailureAnalysis.js
+++ b/lib/src/entities/FailureAnalysis.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/entrypoint.js
+++ b/lib/src/entrypoint.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const index_1 = require("./index");
+(0, index_1.run)();

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,0 +1,338 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.optionalArrayInput = optionalArrayInput;
+exports.optionalInput = optionalInput;
+exports.booleanInput = booleanInput;
+exports.run = run;
+const axios_1 = __importStar(require("axios"));
+const mablApiClient_1 = require("./mablApiClient");
+const table_1 = require("./table");
+const core = __importStar(require("@actions/core"));
+const github = __importStar(require("@actions/github"));
+const constants_1 = require("./constants");
+const deploymentFailure_1 = require("./deploymentFailure");
+const slackNotification_1 = require("./slackNotification");
+const DEFAULT_MABL_APP_URL = 'https://app.mabl.com';
+const EXECUTION_POLL_INTERVAL_MILLIS = 10_000;
+const EXECUTION_COMPLETED_STATUSES = [
+    'succeeded',
+    'failed',
+    'cancelled',
+    'completed',
+    'terminated',
+];
+const GITHUB_BASE_URL = 'https://api.github.com';
+function optionalArrayInput(name) {
+    return core
+        .getInput(name, {
+        required: false,
+    })
+        .split(/[,\n]/)
+        .filter((item) => item.length)
+        .map((item) => item.trim());
+}
+function optionalInput(name) {
+    const rawValue = core.getInput(name, {
+        required: false,
+    });
+    if (rawValue.length > 0) {
+        return rawValue;
+    }
+    return;
+}
+function booleanInput(name) {
+    return (core
+        .getInput(name, {
+        required: false,
+    })
+        .toLowerCase() === 'true');
+}
+async function run(enableFailureExitCodes = true, options) {
+    const executionPollIntervalMs = options?.executionPollIntervalMs ?? EXECUTION_POLL_INTERVAL_MILLIS;
+    const wrappedFailed = (message) => {
+        if (enableFailureExitCodes) {
+            core.setFailed(message);
+        }
+    };
+    let activeDeployment;
+    try {
+        core.startGroup('Gathering inputs');
+        const applicationId = optionalInput(constants_1.ActionInputs.ApplicationId);
+        const environmentId = optionalInput(constants_1.ActionInputs.EnvironmentId);
+        const apiKey = process.env.MABL_API_KEY;
+        if (!apiKey) {
+            wrappedFailed('env var MABL_API_KEY required');
+            return;
+        }
+        const planLabels = optionalArrayInput(constants_1.ActionInputs.PlanLabels);
+        const browserTypes = optionalArrayInput(constants_1.ActionInputs.BrowserTypes);
+        const httpHeaders = optionalArrayInput(constants_1.ActionInputs.HttpHeaders);
+        const uri = optionalInput(constants_1.ActionInputs.Uri);
+        const apiUrl = optionalInput(constants_1.ActionInputs.UrlApi);
+        const appUrl = optionalInput(constants_1.ActionInputs.UrlApp);
+        const mablBranch = optionalInput(constants_1.ActionInputs.MablBranch);
+        const rebaselineImages = booleanInput(constants_1.ActionInputs.RebaselineImages);
+        const setStaticBaseline = booleanInput(constants_1.ActionInputs.SetStaticBaseline);
+        const continueOnPlanFailure = booleanInput(constants_1.ActionInputs.ContinueOnFailure);
+        const pullRequest = await getRelatedPullRequest();
+        const eventTimeString = optionalInput(constants_1.ActionInputs.EventTime);
+        const eventTime = eventTimeString ? parseInt(eventTimeString) : Date.now();
+        if (uri) {
+            core.warning(`[${constants_1.ActionInputs.Uri}] has been deprecated. Please use [${constants_1.ActionInputs.UrlApp}] instead.`);
+        }
+        if (uri && appUrl) {
+            core.warning(`Both [${constants_1.ActionInputs.Uri}] and [${constants_1.ActionInputs.UrlApp}] were set. The value for [${constants_1.ActionInputs.UrlApp}] will be used`);
+        }
+        const effectiveAppUrl = appUrl ?? uri;
+        let properties = {
+            triggering_event_name: process.env.GITHUB_EVENT_NAME,
+            repository_commit_username: process.env.GITHUB_ACTOR,
+            repository_action: process.env.GITHUB_ACTION,
+            repository_branch_name: process.env.GITHUB_REF,
+            repository_name: process.env.GITHUB_REPOSITORY,
+            repository_url: `git@github.com:${process.env.GITHUB_REPOSITORY}.git`,
+        };
+        if (pullRequest) {
+            properties = Object.assign(properties, {
+                repository_pull_request_url: pullRequest.url,
+                repository_pull_request_number: pullRequest.number,
+                repository_pull_request_title: pullRequest.title,
+                repository_pull_request_created_at: pullRequest.created_at,
+            });
+            if (pullRequest.merged_at) {
+                properties.repository_pull_request_merged_at = pullRequest.merged_at;
+            }
+        }
+        const baseAppUrl = process.env.MABL_APP_URL ?? DEFAULT_MABL_APP_URL;
+        const revision = process.env.GITHUB_EVENT_NAME === 'pull_request'
+            ? github.context.payload.pull_request?.head?.sha
+            : process.env.GITHUB_SHA;
+        if (mablBranch) {
+            core.info(`Using mabl branch [${mablBranch}]`);
+        }
+        core.info(`Using git revision [${revision}]`);
+        core.endGroup();
+        core.startGroup('Creating deployment event');
+        const apiClient = new mablApiClient_1.MablApiClient(apiKey);
+        const deployment = await apiClient.postDeploymentEvent(browserTypes, planLabels, httpHeaders, rebaselineImages, setStaticBaseline, eventTime, properties, applicationId, environmentId, effectiveAppUrl, apiUrl, revision, mablBranch);
+        core.setOutput(constants_1.ActionOutputs.DeploymentId, deployment.id);
+        let appOrEnv;
+        if (applicationId) {
+            appOrEnv = await apiClient.getApplication(applicationId);
+        }
+        else if (environmentId) {
+            appOrEnv = await apiClient.getEnvironment(environmentId);
+        }
+        if (!appOrEnv) {
+            wrappedFailed('Invalid configuration. Valid "application-id" or "environment-id" must be set. No tests started.');
+            return;
+        }
+        const effectiveWorkspaceId = appOrEnv.workspace_id ?? appOrEnv.organization_id;
+        const outputLink = `${baseAppUrl}/workspaces/${effectiveWorkspaceId}/events/${deployment.id}`;
+        core.info(`Deployment triggered. View output at: ${outputLink}`);
+        activeDeployment = {
+            apiClient,
+            workspaceId: effectiveWorkspaceId,
+            deploymentId: deployment.id,
+            deploymentPageUrl: outputLink,
+            revision,
+        };
+        core.startGroup('Await completion of tests');
+        let executionComplete = false;
+        while (!executionComplete) {
+            await sleep(executionPollIntervalMs);
+            const executionResult = await apiClient.getExecutionResults(deployment.id);
+            if (executionResult?.executions) {
+                const pendingExecutions = getExecutionsStillPending(executionResult);
+                if (pendingExecutions.length === 0) {
+                    executionComplete = true;
+                }
+                else {
+                    core.info(`${pendingExecutions.length} mabl plan(s) are still running`);
+                }
+            }
+        }
+        core.info('mabl deployment runs have completed');
+        core.endGroup();
+        core.startGroup('Fetch execution results');
+        const finalExecutionResult = await apiClient.getExecutionResults(deployment.id);
+        finalExecutionResult.executions.forEach((execution) => {
+            core.info((0, table_1.prettyFormatExecution)(execution));
+        });
+        core.setOutput(constants_1.ActionOutputs.PlansRun, '' + finalExecutionResult.plan_execution_metrics.total);
+        core.setOutput(constants_1.ActionOutputs.PlansPassed, '' + finalExecutionResult.plan_execution_metrics.passed);
+        core.setOutput(constants_1.ActionOutputs.PlansFailed, '' + finalExecutionResult.plan_execution_metrics.failed);
+        core.setOutput(constants_1.ActionOutputs.TestsRun, '' + finalExecutionResult.journey_execution_metrics.total);
+        core.setOutput(constants_1.ActionOutputs.TestsPassed, '' + finalExecutionResult.journey_execution_metrics.passed);
+        core.setOutput(constants_1.ActionOutputs.TestsFailed, '' + finalExecutionResult.journey_execution_metrics.failed);
+        if (!(0, deploymentFailure_1.deploymentHasFailures)(finalExecutionResult)) {
+            core.debug('Deployment plans passed');
+        }
+        else {
+            await notifySlackForActiveDeployment(activeDeployment, finalExecutionResult);
+            const testsFailed = finalExecutionResult.journey_execution_metrics.failed;
+            const plansFailed = finalExecutionResult.plan_execution_metrics.failed;
+            if (continueOnPlanFailure) {
+                core.warning((0, deploymentFailure_1.formatContinueOnFailureWarning)(testsFailed, plansFailed));
+            }
+            else {
+                wrappedFailed((0, deploymentFailure_1.formatDeploymentFailureMessage)(testsFailed, plansFailed));
+            }
+        }
+        core.endGroup();
+    }
+    catch (err) {
+        if (activeDeployment) {
+            await notifySlackAfterDeploymentTaskError(activeDeployment, err);
+        }
+        wrappedFailed(`mabl deployment task failed for the following reason: ${err}`);
+    }
+}
+function sleep(milliseconds) {
+    return new Promise((resolve, reject) => {
+        try {
+            setTimeout(resolve, milliseconds);
+        }
+        catch (error) {
+            reject(error);
+        }
+    });
+}
+function getExecutionsStillPending(executionResult) {
+    return executionResult.executions.filter((execution) => {
+        return !(EXECUTION_COMPLETED_STATUSES.includes(execution.status) &&
+            execution.stop_time);
+    });
+}
+async function notifySlackForActiveDeployment(activeDeployment, executionResult) {
+    const webhookUrl = (0, slackNotification_1.resolveSlackWebhookUrl)();
+    if (!webhookUrl) {
+        core.info('Skipping Slack notification (set SLACK_WEBHOOK_URL env var to enable)');
+        return;
+    }
+    core.startGroup('Notify Slack on deployment failure');
+    try {
+        await sendSlackDeploymentFailureNotification(webhookUrl, activeDeployment, executionResult);
+        core.info('Slack notification sent');
+    }
+    catch (error) {
+        core.warning(`Failed to send Slack notification: ${error}`);
+    }
+    core.endGroup();
+}
+async function sendSlackDeploymentFailureNotification(webhookUrl, activeDeployment, executionResult) {
+    const workflowContext = (0, slackNotification_1.buildSlackWorkflowContext)();
+    await (0, slackNotification_1.notifySlackOnDeploymentFailure)(webhookUrl, {
+        apiClient: activeDeployment.apiClient,
+        workspaceId: activeDeployment.workspaceId,
+        deploymentEventId: activeDeployment.deploymentId,
+        deploymentPageUrl: activeDeployment.deploymentPageUrl,
+        executionResult,
+        repository: workflowContext.repository,
+        branch: workflowContext.branch,
+        actor: workflowContext.actor,
+        revision: activeDeployment.revision,
+        workflowUrl: workflowContext.workflowUrl,
+    });
+}
+async function notifySlackAfterDeploymentTaskError(activeDeployment, err) {
+    const webhookUrl = (0, slackNotification_1.resolveSlackWebhookUrl)();
+    if (!webhookUrl) {
+        core.info('Skipping Slack notification (set SLACK_WEBHOOK_URL env var to enable)');
+        return;
+    }
+    core.startGroup('Notify Slack on deployment task failure');
+    try {
+        let executionResult;
+        try {
+            executionResult = await activeDeployment.apiClient.getExecutionResults(activeDeployment.deploymentId);
+        }
+        catch (resultsError) {
+            core.warning(`Unable to load execution results for Slack notification: ${resultsError}`);
+        }
+        if (executionResult && (0, deploymentFailure_1.deploymentHasFailures)(executionResult)) {
+            await sendSlackDeploymentFailureNotification(webhookUrl, activeDeployment, executionResult);
+            core.info('Slack notification sent');
+            return;
+        }
+        const workflowContext = (0, slackNotification_1.buildSlackWorkflowContext)();
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        await (0, slackNotification_1.notifySlackOnDeploymentTaskFailure)(webhookUrl, {
+            deploymentPageUrl: activeDeployment.deploymentPageUrl,
+            repository: workflowContext.repository,
+            branch: workflowContext.branch,
+            actor: workflowContext.actor,
+            revision: activeDeployment.revision,
+            workflowUrl: workflowContext.workflowUrl,
+            errorMessage,
+            executionResult,
+        });
+        core.info('Slack notification sent');
+    }
+    catch (error) {
+        core.warning(`Failed to send Slack notification: ${error}`);
+    }
+    core.endGroup();
+}
+async function getRelatedPullRequest() {
+    const targetUrl = `${GITHUB_BASE_URL}/repos/${process.env.GITHUB_REPOSITORY}/commits/${process.env.GITHUB_SHA}/pulls`;
+    const githubToken = process.env.GITHUB_TOKEN;
+    if (!githubToken) {
+        return;
+    }
+    const config = {
+        headers: {
+            Authorization: `token ${githubToken}`,
+            Accept: 'application/vnd.github.groot-preview+json',
+            'Content-Type': 'application/json',
+            'User-Agent': constants_1.USER_AGENT,
+        },
+    };
+    const client = axios_1.default.create(config);
+    try {
+        const response = await client.get(targetUrl, config);
+        return response?.data?.[0];
+    }
+    catch (error) {
+        if ((0, axios_1.isAxiosError)(error) && error.response?.status === 404) {
+            return;
+        }
+        if (error instanceof Error) {
+            core.warning(error.message);
+        }
+    }
+    return;
+}

--- a/lib/src/interfaces.js
+++ b/lib/src/interfaces.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/mablApiClient.js
+++ b/lib/src/mablApiClient.js
@@ -1,0 +1,168 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MablApiClient = void 0;
+const async_retry_1 = __importDefault(require("async-retry"));
+const axios_1 = __importDefault(require("axios"));
+const constants_1 = require("./constants");
+const GET_REQUEST_TIMEOUT_MILLIS = 600_000;
+const POST_REQUEST_TIMEOUT_MILLIS = 900_000;
+class MablApiClient {
+    constructor(apiKey) {
+        this.baseUrl = process.env.MABL_REST_API_URL ?? 'https://api.mabl.com';
+        const config = {
+            headers: {
+                'User-Agent': constants_1.USER_AGENT,
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+            },
+            auth: {
+                username: 'key',
+                password: apiKey,
+            },
+        };
+        this.httpClient = axios_1.default.create(config);
+    }
+    static throwHumanizedError(response) {
+        switch (response.status) {
+            case 401:
+                throw new Error(`Unauthorized API error, are you sure you passed the correct API key? Is the key "enabled"?`);
+            case 403:
+                throw new Error(`Forbidden API error, are you sure you used a "CI/CD Integration" type API key? Ensure this key is for the same workspace you're testing.`);
+            case 404:
+                throw new Error(`Not Found API error, please ensure any environment or application IDs in your Action config are correct.`);
+            default:
+                throw new Error(`[${response.status} - ${response.statusText}]`);
+        }
+    }
+    async makeGetRequest(url) {
+        return (0, async_retry_1.default)(async () => {
+            const response = await this.httpClient.get(url, {
+                timeout: GET_REQUEST_TIMEOUT_MILLIS,
+            });
+            if ((response.status ?? 400) >= 400) {
+                MablApiClient.throwHumanizedError(response);
+            }
+            return response.data;
+        }, {
+            retries: 3,
+        });
+    }
+    async makePostRequest(url, requestBody) {
+        return (0, async_retry_1.default)(async () => {
+            const response = await this.httpClient.post(url, JSON.stringify(requestBody), { timeout: POST_REQUEST_TIMEOUT_MILLIS });
+            if ((response.status ?? 400) >= 400) {
+                throw new Error(`[${response.status} - ${response.statusText}]`);
+            }
+            return response.data;
+        }, {
+            retries: 3,
+        });
+    }
+    async getApplication(id) {
+        try {
+            return await this.makeGetRequest(`${this.baseUrl}/applications/${id}`);
+        }
+        catch (error) {
+            throw new Error(`failed to get mabl application (${id}) from the API ${error}`);
+        }
+    }
+    async getEnvironment(id) {
+        try {
+            return await this.makeGetRequest(`${this.baseUrl}/environments/${id}`);
+        }
+        catch (error) {
+            throw new Error(`failed to get mabl environment (${id}) from the API ${error}`);
+        }
+    }
+    async getExecutionResults(eventId) {
+        try {
+            return await this.makeGetRequest(`${this.baseUrl}/execution/result/event/${eventId}`);
+        }
+        catch (error) {
+            throw new Error(`failed to get mabl execution results for event ${eventId} from the API ${error}`);
+        }
+    }
+    async tryGetSavedDeploymentFailureAnalysis(workspaceId, deploymentEventId) {
+        try {
+            const response = await this.httpClient.get(`${this.baseUrl}/analysis/${workspaceId}/deployment/${deploymentEventId}/summary`, { timeout: GET_REQUEST_TIMEOUT_MILLIS });
+            if ((response.status ?? 400) >= 400) {
+                return undefined;
+            }
+            return response.data;
+        }
+        catch (error) {
+            if (axios_1.default.isAxiosError(error) && error.response?.status === 404) {
+                return undefined;
+            }
+            throw error;
+        }
+    }
+    async postDeploymentEvent(browserTypes, planLabels, httpHeaders, rebaselineImages, setStaticBaseline, eventTime, properties, applicationId, environmentId, appUrl, apiUrl, revision, mablBranch) {
+        try {
+            const requestBody = this.buildRequestBody(browserTypes, planLabels, httpHeaders, rebaselineImages, setStaticBaseline, eventTime, properties, applicationId, environmentId, appUrl, apiUrl, revision, mablBranch);
+            return await this.makePostRequest(`${this.baseUrl}/events/deployment/`, requestBody);
+        }
+        catch (e) {
+            throw new Error(`failed to create deployment through mabl API ${e}`);
+        }
+    }
+    buildRequestBody(browserTypes, planLabels, httpHeaders, rebaselineImages, setStaticBaseline, eventTime, properties, applicationId, environmentId, appUrl, apiUrl, revision, mablBranch) {
+        const requestBody = {};
+        if (environmentId) {
+            requestBody.environment_id = environmentId;
+        }
+        if (applicationId) {
+            requestBody.application_id = applicationId;
+        }
+        if (mablBranch) {
+            requestBody.source_control_tag = mablBranch;
+        }
+        const planOverrides = {};
+        if (browserTypes.length) {
+            planOverrides.browser_types = browserTypes;
+        }
+        if (appUrl) {
+            planOverrides.web_url = appUrl;
+        }
+        if (apiUrl) {
+            planOverrides.api_url = apiUrl;
+        }
+        if (httpHeaders.length) {
+            planOverrides.http_headers = httpHeaders.map((header) => {
+                const parts = header.split(':', 2);
+                return {
+                    name: parts[0],
+                    value: parts[1],
+                    log_header_value: false,
+                };
+            });
+            planOverrides.http_headers_required = true;
+        }
+        requestBody.plan_overrides = planOverrides;
+        if (planLabels.length) {
+            requestBody.plan_labels = planLabels;
+        }
+        if (revision) {
+            requestBody.revision = revision;
+        }
+        if (eventTime) {
+            requestBody.event_time = eventTime;
+        }
+        if (properties) {
+            requestBody.properties = properties;
+        }
+        const actions = {};
+        if (rebaselineImages) {
+            actions.rebaseline_images = rebaselineImages;
+        }
+        if (setStaticBaseline) {
+            actions.set_static_baseline = setStaticBaseline;
+        }
+        requestBody.actions = actions;
+        return requestBody;
+    }
+}
+exports.MablApiClient = MablApiClient;

--- a/lib/src/slackNotification.js
+++ b/lib/src/slackNotification.js
@@ -1,0 +1,215 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.notifySlackOnDeploymentFailure = notifySlackOnDeploymentFailure;
+exports.notifySlackOnDeploymentTaskFailure = notifySlackOnDeploymentTaskFailure;
+exports.resolveSlackWebhookUrl = resolveSlackWebhookUrl;
+exports.buildSlackWorkflowContext = buildSlackWorkflowContext;
+const axios_1 = __importDefault(require("axios"));
+const core = __importStar(require("@actions/core"));
+const deploymentAnalysis_1 = require("./deploymentAnalysis");
+const slackUtil_1 = require("./slackUtil");
+async function notifySlackOnDeploymentFailure(webhookUrl, context) {
+    const metrics = context.executionResult.journey_execution_metrics;
+    const planMetrics = context.executionResult.plan_execution_metrics;
+    let analysisText;
+    try {
+        const analysis = await (0, deploymentAnalysis_1.getDeploymentFailureAnalysisForSlack)(context.apiClient, context.workspaceId, context.deploymentEventId);
+        if (analysis) {
+            analysisText = (0, deploymentAnalysis_1.formatFailureAnalysisForSlack)(analysis);
+        }
+    }
+    catch (error) {
+        core.warning(`Unable to load deployment analysis for Slack notification: ${error}`);
+    }
+    const payload = buildSlackPayload(context, analysisText, metrics, planMetrics);
+    await postSlackWebhook(webhookUrl, payload);
+}
+async function notifySlackOnDeploymentTaskFailure(webhookUrl, context) {
+    const blocks = [
+        {
+            type: 'header',
+            text: {
+                type: 'plain_text',
+                text: 'mabl deployment task failed',
+                emoji: true,
+            },
+        },
+    ];
+    appendContextFields(blocks, context);
+    blocks.push({
+        type: 'section',
+        text: {
+            type: 'markdown',
+            text: (0, slackUtil_1.fitSlackSectionText)(`*Error:*\n${(0, slackUtil_1.escapeSlackMarkdown)(context.errorMessage)}`, slackUtil_1.SLACK_SECTION_TEXT_MAX_CHARS),
+        },
+    });
+    if (context.executionResult) {
+        const metrics = context.executionResult.journey_execution_metrics;
+        const planMetrics = context.executionResult.plan_execution_metrics;
+        blocks.push({
+            type: 'section',
+            text: {
+                type: 'markdown',
+                text: `*Partial results:*\n${metrics.failed} test(s) failed (${metrics.passed}/${metrics.total} passed)\n${planMetrics.failed} plan(s) failed (${planMetrics.passed}/${planMetrics.total} passed)`,
+            },
+        });
+    }
+    blocks.push({
+        type: 'section',
+        text: {
+            type: 'markdown',
+            text: `<${context.deploymentPageUrl}|View deployment in mabl>`,
+        },
+    });
+    appendWorkflowContext(blocks, context.workflowUrl);
+    await postSlackWebhook(webhookUrl, {
+        text: 'mabl deployment task failed',
+        blocks,
+    });
+}
+function buildSlackPayload(context, analysisText, journeyMetrics, planMetrics) {
+    const blocks = [
+        {
+            type: 'header',
+            text: {
+                type: 'plain_text',
+                text: 'mabl deployment tests failed',
+                emoji: true,
+            },
+        },
+    ];
+    appendContextFields(blocks, context);
+    blocks.push({
+        type: 'section',
+        text: {
+            type: 'markdown',
+            text: `*Results:*\n${journeyMetrics.failed} test(s) failed (${journeyMetrics.passed}/${journeyMetrics.total} passed)\n${planMetrics.failed} plan(s) failed (${planMetrics.passed}/${planMetrics.total} passed)`,
+        },
+    });
+    blocks.push({
+        type: 'section',
+        text: {
+            type: 'markdown',
+            text: `<${context.deploymentPageUrl}|View deployment in mabl>`,
+        },
+    });
+    if (analysisText) {
+        blocks.push({
+            type: 'section',
+            text: {
+                type: 'markdown',
+                text: (0, slackUtil_1.fitSlackSectionText)(`*Analysis*\n${analysisText}`, slackUtil_1.SLACK_SECTION_TEXT_MAX_CHARS),
+            },
+        });
+    }
+    appendWorkflowContext(blocks, context.workflowUrl);
+    return {
+        text: `mabl deployment tests failed (${journeyMetrics.failed} test failure(s))`,
+        blocks,
+    };
+}
+function appendContextFields(blocks, context) {
+    const fields = [];
+    if (context.repository) {
+        fields.push({
+            type: 'markdown',
+            text: `*Repository:*\n${(0, slackUtil_1.escapeSlackMarkdown)(context.repository)}`,
+        });
+    }
+    if (context.branch) {
+        fields.push({
+            type: 'markdown',
+            text: `*Branch / ref:*\n\`${(0, slackUtil_1.escapeSlackMarkdown)(context.branch)}\``,
+        });
+    }
+    if (context.revision) {
+        fields.push({
+            type: 'markdown',
+            text: `*Revision:*\n\`${(0, slackUtil_1.escapeSlackMarkdown)(context.revision.slice(0, 7))}\``,
+        });
+    }
+    if (context.actor) {
+        fields.push({
+            type: 'markdown',
+            text: `*Triggered by:*\n${(0, slackUtil_1.escapeSlackMarkdown)(context.actor)}`,
+        });
+    }
+    if (fields.length > 0) {
+        blocks.push({ type: 'section', fields });
+    }
+}
+function appendWorkflowContext(blocks, workflowUrl) {
+    if (!workflowUrl) {
+        return;
+    }
+    blocks.push({
+        type: 'context',
+        elements: [
+            {
+                type: 'markdown',
+                text: `<${workflowUrl}|GitHub Actions workflow run>`,
+            },
+        ],
+    });
+}
+async function postSlackWebhook(webhookUrl, payload) {
+    await axios_1.default.post(webhookUrl, payload, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 30_000,
+    });
+}
+function resolveSlackWebhookUrl() {
+    const fromEnv = process.env.SLACK_WEBHOOK_URL?.trim();
+    if (fromEnv) {
+        return fromEnv;
+    }
+    return undefined;
+}
+function buildSlackWorkflowContext() {
+    const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+    const workflowUrl = process.env.GITHUB_RUN_ID && process.env.GITHUB_REPOSITORY
+        ? `${serverUrl}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : undefined;
+    return {
+        repository: process.env.GITHUB_REPOSITORY,
+        branch: process.env.GITHUB_REF,
+        actor: process.env.GITHUB_ACTOR,
+        workflowUrl,
+    };
+}

--- a/lib/src/slackUtil.js
+++ b/lib/src/slackUtil.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SLACK_SECTION_TEXT_MAX_CHARS = void 0;
+exports.escapeSlackMarkdown = escapeSlackMarkdown;
+exports.fitSlackSectionText = fitSlackSectionText;
+exports.SLACK_SECTION_TEXT_MAX_CHARS = 3_000;
+function escapeSlackMarkdown(text) {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/([*_`~])/g, '$1\u200b');
+}
+function fitSlackSectionText(text, maxChars) {
+    if (text.length <= maxChars) {
+        return text;
+    }
+    return `${text.slice(0, Math.max(0, maxChars - 3))}...`;
+}

--- a/lib/src/table.js
+++ b/lib/src/table.js
@@ -1,0 +1,91 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.prettyFormatExecution = prettyFormatExecution;
+const cli_table3_1 = __importDefault(require("cli-table3"));
+const moment = __importStar(require("moment"));
+function prettyFormatExecution(execution) {
+    let outputString = '';
+    const planTable = new cli_table3_1.default({
+        head: [],
+        style: {
+            head: [],
+            border: [],
+        },
+        colWidths: [15, 30, 15, 13, 15, 20, 17, 130],
+        wordWrap: true,
+    });
+    planTable.push([
+        'Plan Name:',
+        execution.plan.name,
+        'Status:',
+        execution.success ? 'Passed' : 'Failed',
+        'Duration:',
+        moment.utc(execution.stop_time - execution.start_time).format('HH:mm:ss'),
+        'mabl App Link:',
+        execution.plan.app_href,
+    ]);
+    const testTable = new cli_table3_1.default({
+        head: ['Browser', 'Status', 'Test Name', 'Duration', 'mabl App Link'],
+        style: {
+            head: [],
+            border: [],
+        },
+        colWidths: [10, 15, 27, 15, 160],
+        wordWrap: true,
+    });
+    execution.journey_executions.forEach((journeyExecution) => {
+        const test = execution.journeys.find((test) => test.id === journeyExecution.journey_id);
+        testTable.push([
+            journeyExecution.browser_type,
+            journeyExecution.success ? 'Passed' : 'Failed',
+            test ? test.name : journeyExecution.journey_id,
+            moment
+                .utc(journeyExecution.stop_time - journeyExecution.start_time)
+                .format('HH:mm:ss'),
+            journeyExecution.app_href,
+        ]);
+    });
+    outputString += outputTable(planTable);
+    outputString += '\n';
+    outputString += outputTable(testTable);
+    return outputString;
+}
+function outputTable(table) {
+    return table.toString().replace(/[\r\n]+/, '\n    ');
+}

--- a/src/deploymentAnalysis.ts
+++ b/src/deploymentAnalysis.ts
@@ -1,0 +1,181 @@
+import axios from 'axios';
+import * as core from '@actions/core';
+import {MablApiClient} from './mablApiClient';
+import {
+  FailureAnalysis,
+  FailureAnalysisResponse,
+} from './entities/FailureAnalysis';
+import {escapeSlackMarkdown, fitSlackSectionText} from './slackUtil';
+
+export interface DeploymentAnalysisPollOptions {
+  pollIntervalMs?: number;
+  maxPollAttempts?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export const DEFAULT_POLL_INTERVAL_MS = 2_000;
+export const DEFAULT_MAX_POLL_ATTEMPTS = 10;
+
+const SLACK_ANALYSIS_BODY_MAX_CHARS = 2_700;
+
+export async function getDeploymentFailureAnalysisForSlack(
+  apiClient: MablApiClient,
+  workspaceId: string,
+  deploymentEventId: string,
+  pollOptions?: DeploymentAnalysisPollOptions,
+): Promise<FailureAnalysis | undefined> {
+  const response = await pollForSavedDeploymentFailureAnalysis(
+    apiClient,
+    workspaceId,
+    deploymentEventId,
+    pollOptions,
+  );
+  return response?.analysis;
+}
+
+export function formatFailureAnalysisForSlack(
+  analysis: FailureAnalysis,
+): string | undefined {
+  const synopsis = analysis.synopsis?.trim();
+  const summaryText = analysis.summary_text?.trim();
+
+  if (!synopsis && !summaryText) {
+    return undefined;
+  }
+
+  const sections: string[] = [];
+  if (synopsis) {
+    sections.push(`*${escapeSlackMarkdown(synopsis)}*`);
+  }
+  if (summaryText) {
+    sections.push(escapeSlackMarkdown(summaryText));
+  }
+
+  return fitSlackSectionText(
+    sections.join('\n\n'),
+    SLACK_ANALYSIS_BODY_MAX_CHARS,
+  );
+}
+
+function getAnalysisFromResponse(
+  response: FailureAnalysisResponse,
+): FailureAnalysis | undefined {
+  if (response.status !== 'done' || !response.analysis) {
+    return undefined;
+  }
+  return response.analysis;
+}
+
+function formatAnalysisFetchError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    if (status === 403) {
+      return 'HTTP 403 (forbidden — API key may lack analysis permissions)';
+    }
+    if (status !== undefined) {
+      return `HTTP ${status}`;
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+async function pollForSavedDeploymentFailureAnalysis(
+  apiClient: MablApiClient,
+  workspaceId: string,
+  deploymentEventId: string,
+  pollOptions?: DeploymentAnalysisPollOptions,
+): Promise<FailureAnalysisResponse | undefined> {
+  const maxAttempts = pollOptions?.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
+  const pollIntervalMs =
+    pollOptions?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const sleepFn = pollOptions?.sleep ?? sleep;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await apiClient.tryGetSavedDeploymentFailureAnalysis(
+        workspaceId,
+        deploymentEventId,
+      );
+
+      if (response === undefined) {
+        if (attempt < maxAttempts) {
+          if (attempt === 1) {
+            core.info(
+              `Deployment analysis not ready for event [${deploymentEventId}], polling up to ${maxAttempts} attempt(s)`,
+            );
+          }
+          await sleepFn(pollIntervalMs);
+          continue;
+        }
+
+        core.info(
+          `No deployment analysis for event [${deploymentEventId}] after ${maxAttempts} poll attempt(s)`,
+        );
+        return undefined;
+      }
+
+      const analysis = getAnalysisFromResponse(response);
+      if (analysis) {
+        if (attempt > 1) {
+          core.info(
+            `Deployment analysis ready for event [${deploymentEventId}] after ${attempt} poll attempt(s)`,
+          );
+        }
+        return response;
+      }
+
+      if (response.status === 'queued' && attempt < maxAttempts) {
+        if (attempt === 1) {
+          core.info(
+            `Deployment analysis queued for event [${deploymentEventId}], polling up to ${maxAttempts} attempt(s)`,
+          );
+        }
+        await sleepFn(pollIntervalMs);
+        continue;
+      }
+
+      if (response.status === 'queued') {
+        core.info(
+          `Deployment analysis still queued for event [${deploymentEventId}] after ${maxAttempts} poll attempt(s); giving up`,
+        );
+      }
+
+      return undefined;
+    } catch (error) {
+      const message = formatAnalysisFetchError(error);
+      if (axios.isAxiosError(error) && error.response?.status === 403) {
+        core.warning(
+          `Deployment analysis unavailable for event [${deploymentEventId}]: ${message}`,
+        );
+        return undefined;
+      }
+
+      if (attempt < maxAttempts) {
+        core.warning(
+          `Failed to fetch deployment analysis for event [${deploymentEventId}] (attempt ${attempt}/${maxAttempts}): ${message}`,
+        );
+        await sleepFn(pollIntervalMs);
+        continue;
+      }
+
+      core.warning(
+        `Failed to fetch deployment analysis for event [${deploymentEventId}] after ${maxAttempts} poll attempt(s): ${message}`,
+      );
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  // eslint-disable-next-line no-restricted-globals
+  return new Promise((resolve) => {
+    // eslint-disable-next-line no-restricted-globals
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/src/deploymentFailure.ts
+++ b/src/deploymentFailure.ts
@@ -1,0 +1,42 @@
+import {ExecutionResult} from './entities/ExecutionResult';
+
+export function deploymentHasFailures(
+  executionResult: ExecutionResult,
+): boolean {
+  return (
+    executionResult.journey_execution_metrics.failed > 0 ||
+    executionResult.plan_execution_metrics.failed > 0
+  );
+}
+
+export function formatDeploymentFailureMessage(
+  testsFailed: number,
+  plansFailed: number,
+): string {
+  const parts: string[] = [];
+  if (testsFailed > 0) {
+    parts.push(`${testsFailed} mabl test(s) failed`);
+  }
+  if (plansFailed > 0) {
+    parts.push(`${plansFailed} mabl plan(s) failed`);
+  }
+  if (parts.length === 0) {
+    return 'mabl deployment failed';
+  }
+  return parts.join(' and ');
+}
+
+export function formatContinueOnFailureWarning(
+  testsFailed: number,
+  plansFailed: number,
+): string {
+  const parts: string[] = [];
+  if (testsFailed > 0) {
+    parts.push(`${testsFailed} test failure(s)`);
+  }
+  if (plansFailed > 0) {
+    parts.push(`${plansFailed} plan failure(s)`);
+  }
+  const summary = parts.join(' and ') || 'failures';
+  return `There were ${summary} but the continueOnPlanFailure flag is set so the task has been marked as passing`;
+}

--- a/src/entities/FailureAnalysis.ts
+++ b/src/entities/FailureAnalysis.ts
@@ -1,0 +1,11 @@
+export type FailureAnalysisStatus = 'queued' | 'done' | 'unavailable';
+
+export interface FailureAnalysis {
+  synopsis?: string;
+  summary_text?: string;
+}
+
+export interface FailureAnalysisResponse {
+  status?: FailureAnalysisStatus;
+  analysis?: FailureAnalysis;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import axios, {AxiosRequestConfig} from 'axios';
+import axios, {AxiosRequestConfig, isAxiosError} from 'axios';
 import {MablApiClient} from './mablApiClient';
 import {
   Deployment,
@@ -10,9 +10,20 @@ import {Execution, ExecutionResult} from './entities/ExecutionResult';
 import {prettyFormatExecution} from './table';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import {Option, AxiosError} from './interfaces';
+import {Option} from './interfaces';
 import {Environment} from './entities/Environment';
 import {ActionInputs, ActionOutputs, USER_AGENT} from './constants';
+import {
+  deploymentHasFailures,
+  formatContinueOnFailureWarning,
+  formatDeploymentFailureMessage,
+} from './deploymentFailure';
+import {
+  buildSlackWorkflowContext,
+  notifySlackOnDeploymentFailure,
+  notifySlackOnDeploymentTaskFailure,
+  resolveSlackWebhookUrl,
+} from './slackNotification';
 
 const DEFAULT_MABL_APP_URL = 'https://app.mabl.com';
 const EXECUTION_POLL_INTERVAL_MILLIS = 10_000;
@@ -24,6 +35,14 @@ const EXECUTION_COMPLETED_STATUSES = [
   'terminated',
 ];
 const GITHUB_BASE_URL = 'https://api.github.com';
+
+interface ActiveDeploymentContext {
+  apiClient: MablApiClient;
+  workspaceId: string;
+  deploymentId: string;
+  deploymentPageUrl: string;
+  revision?: string;
+}
 
 export function optionalArrayInput(name: string): string[] {
   // Note: GitHub Action inputs default to '' for undefined inputs, remove these
@@ -57,13 +76,20 @@ export function booleanInput(name: string): boolean {
   );
 }
 
-export async function run(enableFailureExitCodes = true): Promise<void> {
+export async function run(
+  enableFailureExitCodes = true,
+  options?: {executionPollIntervalMs?: number},
+): Promise<void> {
+  const executionPollIntervalMs =
+    options?.executionPollIntervalMs ?? EXECUTION_POLL_INTERVAL_MILLIS;
   const wrappedFailed = (message: string): void => {
     // Allow disabling, otherwise units will always fail in workflow builds w/ process exit code 1
     if (enableFailureExitCodes) {
       core.setFailed(message);
     }
   };
+
+  let activeDeployment: ActiveDeploymentContext | undefined;
 
   try {
     core.startGroup('Gathering inputs');
@@ -189,12 +215,20 @@ export async function run(enableFailureExitCodes = true): Promise<void> {
     const outputLink = `${baseAppUrl}/workspaces/${effectiveWorkspaceId}/events/${deployment.id}`;
     core.info(`Deployment triggered. View output at: ${outputLink}`);
 
+    activeDeployment = {
+      apiClient,
+      workspaceId: effectiveWorkspaceId,
+      deploymentId: deployment.id,
+      deploymentPageUrl: outputLink,
+      revision,
+    };
+
     core.startGroup('Await completion of tests');
 
     // poll Execution result until complete
     let executionComplete = false;
     while (!executionComplete) {
-      await sleep(EXECUTION_POLL_INTERVAL_MILLIS);
+      await sleep(executionPollIntervalMs);
 
       const executionResult = await apiClient.getExecutionResults(
         deployment.id,
@@ -248,19 +282,28 @@ export async function run(enableFailureExitCodes = true): Promise<void> {
       '' + finalExecutionResult.journey_execution_metrics.failed,
     );
 
-    if (finalExecutionResult.journey_execution_metrics.failed === 0) {
+    if (!deploymentHasFailures(finalExecutionResult)) {
       core.debug('Deployment plans passed');
-    } else if (continueOnPlanFailure) {
-      core.warning(
-        `There were ${finalExecutionResult.journey_execution_metrics.failed} test failures but the continueOnPlanFailure flag is set so the task has been marked as passing`,
-      );
     } else {
-      wrappedFailed(
-        `${finalExecutionResult.journey_execution_metrics.failed} mabl test(s) failed`,
+      await notifySlackForActiveDeployment(
+        activeDeployment,
+        finalExecutionResult,
       );
+
+      const testsFailed = finalExecutionResult.journey_execution_metrics.failed;
+      const plansFailed = finalExecutionResult.plan_execution_metrics.failed;
+
+      if (continueOnPlanFailure) {
+        core.warning(formatContinueOnFailureWarning(testsFailed, plansFailed));
+      } else {
+        wrappedFailed(formatDeploymentFailureMessage(testsFailed, plansFailed));
+      }
     }
     core.endGroup();
   } catch (err) {
+    if (activeDeployment) {
+      await notifySlackAfterDeploymentTaskError(activeDeployment, err);
+    }
     wrappedFailed(
       `mabl deployment task failed for the following reason: ${err}`,
     );
@@ -290,6 +333,106 @@ function getExecutionsStillPending(
   });
 }
 
+async function notifySlackForActiveDeployment(
+  activeDeployment: ActiveDeploymentContext,
+  executionResult: ExecutionResult,
+): Promise<void> {
+  const webhookUrl = resolveSlackWebhookUrl();
+  if (!webhookUrl) {
+    core.info(
+      'Skipping Slack notification (set SLACK_WEBHOOK_URL env var to enable)',
+    );
+    return;
+  }
+
+  core.startGroup('Notify Slack on deployment failure');
+  try {
+    await sendSlackDeploymentFailureNotification(
+      webhookUrl,
+      activeDeployment,
+      executionResult,
+    );
+    core.info('Slack notification sent');
+  } catch (error) {
+    core.warning(`Failed to send Slack notification: ${error}`);
+  }
+  core.endGroup();
+}
+
+async function sendSlackDeploymentFailureNotification(
+  webhookUrl: string,
+  activeDeployment: ActiveDeploymentContext,
+  executionResult: ExecutionResult,
+): Promise<void> {
+  const workflowContext = buildSlackWorkflowContext();
+  await notifySlackOnDeploymentFailure(webhookUrl, {
+    apiClient: activeDeployment.apiClient,
+    workspaceId: activeDeployment.workspaceId,
+    deploymentEventId: activeDeployment.deploymentId,
+    deploymentPageUrl: activeDeployment.deploymentPageUrl,
+    executionResult,
+    repository: workflowContext.repository,
+    branch: workflowContext.branch,
+    actor: workflowContext.actor,
+    revision: activeDeployment.revision,
+    workflowUrl: workflowContext.workflowUrl,
+  });
+}
+
+async function notifySlackAfterDeploymentTaskError(
+  activeDeployment: ActiveDeploymentContext,
+  err: unknown,
+): Promise<void> {
+  const webhookUrl = resolveSlackWebhookUrl();
+  if (!webhookUrl) {
+    core.info(
+      'Skipping Slack notification (set SLACK_WEBHOOK_URL env var to enable)',
+    );
+    return;
+  }
+
+  core.startGroup('Notify Slack on deployment task failure');
+  try {
+    let executionResult: ExecutionResult | undefined;
+    try {
+      executionResult = await activeDeployment.apiClient.getExecutionResults(
+        activeDeployment.deploymentId,
+      );
+    } catch (resultsError) {
+      core.warning(
+        `Unable to load execution results for Slack notification: ${resultsError}`,
+      );
+    }
+
+    if (executionResult && deploymentHasFailures(executionResult)) {
+      await sendSlackDeploymentFailureNotification(
+        webhookUrl,
+        activeDeployment,
+        executionResult,
+      );
+      core.info('Slack notification sent');
+      return;
+    }
+
+    const workflowContext = buildSlackWorkflowContext();
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    await notifySlackOnDeploymentTaskFailure(webhookUrl, {
+      deploymentPageUrl: activeDeployment.deploymentPageUrl,
+      repository: workflowContext.repository,
+      branch: workflowContext.branch,
+      actor: workflowContext.actor,
+      revision: activeDeployment.revision,
+      workflowUrl: workflowContext.workflowUrl,
+      errorMessage,
+      executionResult,
+    });
+    core.info('Slack notification sent');
+  } catch (error) {
+    core.warning(`Failed to send Slack notification: ${error}`);
+  }
+  core.endGroup();
+}
+
 async function getRelatedPullRequest(): Promise<Option<PullRequest>> {
   const targetUrl = `${GITHUB_BASE_URL}/repos/${process.env.GITHUB_REPOSITORY}/commits/${process.env.GITHUB_SHA}/pulls`;
 
@@ -312,9 +455,11 @@ async function getRelatedPullRequest(): Promise<Option<PullRequest>> {
     const response = await client.get<PullRequest[]>(targetUrl, config);
     return response?.data?.[0];
   } catch (error: unknown) {
-    const maybeAxiosError = error as AxiosError;
-    if (maybeAxiosError.status !== 404) {
-      core.warning(maybeAxiosError.message);
+    if (isAxiosError(error) && error.response?.status === 404) {
+      return;
+    }
+    if (error instanceof Error) {
+      core.warning(error.message);
     }
   }
 

--- a/src/mablApiClient.ts
+++ b/src/mablApiClient.ts
@@ -4,6 +4,7 @@ import {Deployment, DeploymentProperties} from './entities/Deployment';
 import {ExecutionResult} from './entities/ExecutionResult';
 import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios';
 import {Environment} from './entities/Environment';
+import {FailureAnalysisResponse} from './entities/FailureAnalysis';
 import {USER_AGENT} from './constants';
 
 const GET_REQUEST_TIMEOUT_MILLIS = 600_000;
@@ -122,6 +123,30 @@ export class MablApiClient {
       throw new Error(
         `failed to get mabl execution results for event ${eventId} from the API ${error}`,
       );
+    }
+  }
+
+  /**
+   * Load saved deployment failure analysis when available. Returns undefined on 404.
+   */
+  async tryGetSavedDeploymentFailureAnalysis(
+    workspaceId: string,
+    deploymentEventId: string,
+  ): Promise<FailureAnalysisResponse | undefined> {
+    try {
+      const response = await this.httpClient.get<FailureAnalysisResponse>(
+        `${this.baseUrl}/analysis/${workspaceId}/deployment/${deploymentEventId}/summary`,
+        {timeout: GET_REQUEST_TIMEOUT_MILLIS},
+      );
+      if ((response.status ?? 400) >= 400) {
+        return undefined;
+      }
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        return undefined;
+      }
+      throw error;
     }
   }
 

--- a/src/slackNotification.ts
+++ b/src/slackNotification.ts
@@ -1,0 +1,279 @@
+import axios from 'axios';
+import * as core from '@actions/core';
+import {ExecutionResult} from './entities/ExecutionResult';
+import {
+  formatFailureAnalysisForSlack,
+  getDeploymentFailureAnalysisForSlack,
+} from './deploymentAnalysis';
+import {MablApiClient} from './mablApiClient';
+import {
+  escapeSlackMarkdown,
+  fitSlackSectionText,
+  SLACK_SECTION_TEXT_MAX_CHARS,
+} from './slackUtil';
+
+export interface SlackFailureNotificationContext {
+  apiClient: MablApiClient;
+  workspaceId: string;
+  deploymentEventId: string;
+  deploymentPageUrl: string;
+  executionResult: ExecutionResult;
+  repository?: string;
+  branch?: string;
+  actor?: string;
+  revision?: string;
+  workflowUrl?: string;
+}
+
+export interface SlackTaskFailureContext {
+  deploymentPageUrl: string;
+  repository?: string;
+  branch?: string;
+  actor?: string;
+  revision?: string;
+  workflowUrl?: string;
+  errorMessage: string;
+  executionResult?: ExecutionResult;
+}
+
+export async function notifySlackOnDeploymentFailure(
+  webhookUrl: string,
+  context: SlackFailureNotificationContext,
+): Promise<void> {
+  const metrics = context.executionResult.journey_execution_metrics;
+  const planMetrics = context.executionResult.plan_execution_metrics;
+
+  let analysisText: string | undefined;
+  try {
+    const analysis = await getDeploymentFailureAnalysisForSlack(
+      context.apiClient,
+      context.workspaceId,
+      context.deploymentEventId,
+    );
+    if (analysis) {
+      analysisText = formatFailureAnalysisForSlack(analysis);
+    }
+  } catch (error) {
+    core.warning(
+      `Unable to load deployment analysis for Slack notification: ${error}`,
+    );
+  }
+
+  const payload = buildSlackPayload(
+    context,
+    analysisText,
+    metrics,
+    planMetrics,
+  );
+
+  await postSlackWebhook(webhookUrl, payload);
+}
+
+export async function notifySlackOnDeploymentTaskFailure(
+  webhookUrl: string,
+  context: SlackTaskFailureContext,
+): Promise<void> {
+  const blocks: object[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: 'mabl deployment task failed',
+        emoji: true,
+      },
+    },
+  ];
+
+  appendContextFields(blocks, context);
+
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'markdown',
+      text: fitSlackSectionText(
+        `*Error:*\n${escapeSlackMarkdown(context.errorMessage)}`,
+        SLACK_SECTION_TEXT_MAX_CHARS,
+      ),
+    },
+  });
+
+  if (context.executionResult) {
+    const metrics = context.executionResult.journey_execution_metrics;
+    const planMetrics = context.executionResult.plan_execution_metrics;
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'markdown',
+        text: `*Partial results:*\n${metrics.failed} test(s) failed (${metrics.passed}/${metrics.total} passed)\n${planMetrics.failed} plan(s) failed (${planMetrics.passed}/${planMetrics.total} passed)`,
+      },
+    });
+  }
+
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'markdown',
+      text: `<${context.deploymentPageUrl}|View deployment in mabl>`,
+    },
+  });
+
+  appendWorkflowContext(blocks, context.workflowUrl);
+
+  await postSlackWebhook(webhookUrl, {
+    text: 'mabl deployment task failed',
+    blocks,
+  });
+}
+
+function buildSlackPayload(
+  context: SlackFailureNotificationContext,
+  analysisText: string | undefined,
+  journeyMetrics: ExecutionResult['journey_execution_metrics'],
+  planMetrics: ExecutionResult['plan_execution_metrics'],
+): object {
+  const blocks: object[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: 'mabl deployment tests failed',
+        emoji: true,
+      },
+    },
+  ];
+
+  appendContextFields(blocks, context);
+
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'markdown',
+      text: `*Results:*\n${journeyMetrics.failed} test(s) failed (${journeyMetrics.passed}/${journeyMetrics.total} passed)\n${planMetrics.failed} plan(s) failed (${planMetrics.passed}/${planMetrics.total} passed)`,
+    },
+  });
+
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'markdown',
+      text: `<${context.deploymentPageUrl}|View deployment in mabl>`,
+    },
+  });
+
+  if (analysisText) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'markdown',
+        text: fitSlackSectionText(
+          `*Analysis*\n${analysisText}`,
+          SLACK_SECTION_TEXT_MAX_CHARS,
+        ),
+      },
+    });
+  }
+
+  appendWorkflowContext(blocks, context.workflowUrl);
+
+  return {
+    text: `mabl deployment tests failed (${journeyMetrics.failed} test failure(s))`,
+    blocks,
+  };
+}
+
+function appendContextFields(
+  blocks: object[],
+  context: {
+    repository?: string;
+    branch?: string;
+    actor?: string;
+    revision?: string;
+  },
+): void {
+  const fields: {type: string; text: string}[] = [];
+
+  if (context.repository) {
+    fields.push({
+      type: 'markdown',
+      text: `*Repository:*\n${escapeSlackMarkdown(context.repository)}`,
+    });
+  }
+  if (context.branch) {
+    fields.push({
+      type: 'markdown',
+      text: `*Branch / ref:*\n\`${escapeSlackMarkdown(context.branch)}\``,
+    });
+  }
+  if (context.revision) {
+    fields.push({
+      type: 'markdown',
+      text: `*Revision:*\n\`${escapeSlackMarkdown(
+        context.revision.slice(0, 7),
+      )}\``,
+    });
+  }
+  if (context.actor) {
+    fields.push({
+      type: 'markdown',
+      text: `*Triggered by:*\n${escapeSlackMarkdown(context.actor)}`,
+    });
+  }
+
+  if (fields.length > 0) {
+    blocks.push({type: 'section', fields});
+  }
+}
+
+function appendWorkflowContext(blocks: object[], workflowUrl?: string): void {
+  if (!workflowUrl) {
+    return;
+  }
+
+  blocks.push({
+    type: 'context',
+    elements: [
+      {
+        type: 'markdown',
+        text: `<${workflowUrl}|GitHub Actions workflow run>`,
+      },
+    ],
+  });
+}
+
+async function postSlackWebhook(
+  webhookUrl: string,
+  payload: object,
+): Promise<void> {
+  await axios.post(webhookUrl, payload, {
+    headers: {'Content-Type': 'application/json'},
+    timeout: 30_000,
+  });
+}
+
+export function resolveSlackWebhookUrl(): string | undefined {
+  const fromEnv = process.env.SLACK_WEBHOOK_URL?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return undefined;
+}
+
+export function buildSlackWorkflowContext(): {
+  repository?: string;
+  branch?: string;
+  actor?: string;
+  workflowUrl?: string;
+} {
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+  const workflowUrl =
+    process.env.GITHUB_RUN_ID && process.env.GITHUB_REPOSITORY
+      ? `${serverUrl}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : undefined;
+
+  return {
+    repository: process.env.GITHUB_REPOSITORY,
+    branch: process.env.GITHUB_REF,
+    actor: process.env.GITHUB_ACTOR,
+    workflowUrl,
+  };
+}

--- a/src/slackUtil.ts
+++ b/src/slackUtil.ts
@@ -1,0 +1,18 @@
+/** Slack section block `text` fields are limited to 3000 characters. */
+export const SLACK_SECTION_TEXT_MAX_CHARS = 3_000;
+
+/** Escape characters that break Slack markdown or create unintended links. */
+export function escapeSlackMarkdown(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/([*_`~])/g, '$1\u200b');
+}
+
+export function fitSlackSectionText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxChars - 3))}...`;
+}

--- a/test/deploymentAnalysis.test.ts
+++ b/test/deploymentAnalysis.test.ts
@@ -1,0 +1,127 @@
+import {MablApiClient} from '../src/mablApiClient';
+import {
+  DEFAULT_MAX_POLL_ATTEMPTS,
+  formatFailureAnalysisForSlack,
+  getDeploymentFailureAnalysisForSlack,
+} from '../src/deploymentAnalysis';
+import {FailureAnalysisResponse} from '../src/entities/FailureAnalysis';
+
+describe('deploymentAnalysis', () => {
+  describe('formatFailureAnalysisForSlack', () => {
+    it('formats synopsis and summary with escaped markdown', () => {
+      const text = formatFailureAnalysisForSlack({
+        synopsis: 'Login <script> broke',
+        summary_text: 'The submit *button* did not respond.',
+      });
+
+      expect(text).toContain('*Login &lt;script&gt; broke*');
+      expect(text).toContain('submit *​button*');
+      expect(text).not.toContain('View full analysis');
+    });
+
+    it('returns undefined when analysis has no text', () => {
+      expect(formatFailureAnalysisForSlack({})).toBeUndefined();
+    });
+
+    it('truncates long summary text', () => {
+      const text = formatFailureAnalysisForSlack({
+        summary_text: 'x'.repeat(3_000),
+      });
+
+      expect(text).toBeDefined();
+      expect(text?.length).toBeLessThanOrEqual(2_700);
+      expect(text).toContain('...');
+    });
+  });
+
+  describe('getDeploymentFailureAnalysisForSlack', () => {
+    it('defaults to 10 poll attempts', () => {
+      expect(DEFAULT_MAX_POLL_ATTEMPTS).toBe(10);
+    });
+
+    it('polls until analysis is done', async () => {
+      const queued: FailureAnalysisResponse = {status: 'queued'};
+      const done: FailureAnalysisResponse = {
+        status: 'done',
+        analysis: {synopsis: 'Done', summary_text: 'Root cause'},
+      };
+
+      const tryGetSavedDeploymentFailureAnalysis = jest
+        .fn()
+        .mockResolvedValueOnce(queued)
+        .mockResolvedValueOnce(done);
+
+      const apiClient = {
+        tryGetSavedDeploymentFailureAnalysis,
+      } as unknown as MablApiClient;
+
+      const analysis = await getDeploymentFailureAnalysisForSlack(
+        apiClient,
+        'workspace-id',
+        'deployment-id',
+        {
+          pollIntervalMs: 1,
+          maxPollAttempts: 10,
+          sleep: async () => undefined,
+        },
+      );
+
+      expect(analysis).toEqual(done.analysis);
+      expect(tryGetSavedDeploymentFailureAnalysis).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries when analysis is not found yet', async () => {
+      const done: FailureAnalysisResponse = {
+        status: 'done',
+        analysis: {synopsis: 'Ready'},
+      };
+
+      const tryGetSavedDeploymentFailureAnalysis = jest
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(done);
+
+      const apiClient = {
+        tryGetSavedDeploymentFailureAnalysis,
+      } as unknown as MablApiClient;
+
+      const analysis = await getDeploymentFailureAnalysisForSlack(
+        apiClient,
+        'workspace-id',
+        'deployment-id',
+        {
+          pollIntervalMs: 1,
+          maxPollAttempts: 10,
+          sleep: async () => undefined,
+        },
+      );
+
+      expect(analysis).toEqual(done.analysis);
+      expect(tryGetSavedDeploymentFailureAnalysis).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after max attempts while queued', async () => {
+      const tryGetSavedDeploymentFailureAnalysis = jest
+        .fn()
+        .mockResolvedValue({status: 'queued'});
+
+      const apiClient = {
+        tryGetSavedDeploymentFailureAnalysis,
+      } as unknown as MablApiClient;
+
+      const analysis = await getDeploymentFailureAnalysisForSlack(
+        apiClient,
+        'workspace-id',
+        'deployment-id',
+        {
+          pollIntervalMs: 1,
+          maxPollAttempts: 3,
+          sleep: async () => undefined,
+        },
+      );
+
+      expect(analysis).toBeUndefined();
+      expect(tryGetSavedDeploymentFailureAnalysis).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/test/runSlack.test.ts
+++ b/test/runSlack.test.ts
@@ -1,0 +1,168 @@
+import * as core from '@actions/core';
+import {ActionInputs} from '../src/constants';
+import {run} from '../src/index';
+import {
+  notifySlackOnDeploymentFailure,
+  notifySlackOnDeploymentTaskFailure,
+} from '../src/slackNotification';
+
+const mockPostDeploymentEvent = jest.fn();
+const mockGetApplication = jest.fn();
+const mockGetExecutionResults = jest.fn();
+const mockTryGetSavedDeploymentFailureAnalysis = jest.fn();
+
+jest.mock('../src/mablApiClient', () => ({
+  MablApiClient: jest.fn().mockImplementation(() => ({
+    postDeploymentEvent: mockPostDeploymentEvent,
+    getApplication: mockGetApplication,
+    getEnvironment: jest.fn(),
+    getExecutionResults: mockGetExecutionResults,
+    tryGetSavedDeploymentFailureAnalysis:
+      mockTryGetSavedDeploymentFailureAnalysis,
+  })),
+}));
+
+jest.mock('../src/slackNotification', () => {
+  const actual = jest.requireActual('../src/slackNotification');
+  return {
+    ...actual,
+    notifySlackOnDeploymentFailure: jest.fn().mockResolvedValue(undefined),
+    notifySlackOnDeploymentTaskFailure: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockedNotifySlackOnDeploymentFailure =
+  notifySlackOnDeploymentFailure as jest.MockedFunction<
+    typeof notifySlackOnDeploymentFailure
+  >;
+const mockedNotifySlackOnDeploymentTaskFailure =
+  notifySlackOnDeploymentTaskFailure as jest.MockedFunction<
+    typeof notifySlackOnDeploymentTaskFailure
+  >;
+
+function setGithubInput(name: string, value: string): void {
+  process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = value;
+}
+
+function completedExecution(overrides: {success?: boolean; running?: boolean}) {
+  return {
+    status: overrides.running
+      ? 'running'
+      : overrides.success === false
+        ? 'failed'
+        : 'succeeded',
+    success: overrides.success ?? true,
+    plan: {
+      id: 'plan-1',
+      name: 'Smoke plan',
+      href: 'https://api.mabl.com/plan/1',
+      app_href: 'https://app.mabl.com/plan/1',
+    },
+    plan_execution: {
+      id: 'pe-1',
+      status: 'completed',
+      href: 'https://api.mabl.com/pe/1',
+    },
+    journeys: [],
+    journey_executions: [],
+    start_time: 1,
+    stop_time: overrides.running ? 0 : 2,
+  };
+}
+
+function failedExecutionResult() {
+  return {
+    plan_execution_metrics: {total: 1, passed: 0, failed: 1},
+    journey_execution_metrics: {total: 2, passed: 0, failed: 2},
+    executions: [completedExecution({success: false})],
+  };
+}
+
+describe('run() Slack integration', () => {
+  const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => undefined);
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {...originalEnv};
+    delete process.exitCode;
+
+    process.env.MABL_API_KEY = 'test-api-key';
+    process.env.GITHUB_REPOSITORY = 'mablhq/example';
+    process.env.GITHUB_SHA = 'abc1234567890123456789012345678901234567890';
+    process.env.GITHUB_REF = 'refs/heads/main';
+    process.env.GITHUB_ACTOR = 'octocat';
+    process.env.GITHUB_EVENT_NAME = 'push';
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
+
+    setGithubInput(ActionInputs.ApplicationId, 'app-id');
+    setGithubInput(ActionInputs.EnvironmentId, '');
+
+    mockPostDeploymentEvent.mockResolvedValue({id: 'deployment-1'});
+    mockGetApplication.mockResolvedValue({
+      id: 'app-id',
+      workspace_id: 'workspace-1',
+      organization_id: 'org-1',
+      name: 'Example app',
+      created_time: 0,
+      created_by_id: 'user',
+      last_updated_time: 0,
+      last_updated_by_id: 'user',
+    });
+    mockTryGetSavedDeploymentFailureAnalysis.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    infoSpy.mockRestore();
+  });
+
+  it('notifies Slack when deployment tests fail', async () => {
+    mockGetExecutionResults.mockResolvedValue(failedExecutionResult());
+
+    await run(false, {executionPollIntervalMs: 0});
+
+    expect(mockedNotifySlackOnDeploymentFailure).toHaveBeenCalledTimes(1);
+    expect(mockedNotifySlackOnDeploymentFailure.mock.calls[0][0]).toBe(
+      'https://hooks.slack.com/services/test',
+    );
+    expect(
+      mockedNotifySlackOnDeploymentFailure.mock.calls[0][1].deploymentEventId,
+    ).toBe('deployment-1');
+    expect(mockedNotifySlackOnDeploymentTaskFailure).not.toHaveBeenCalled();
+  });
+
+  it('notifies Slack on task error after deployment is triggered', async () => {
+    const pendingResults = {
+      plan_execution_metrics: {total: 0, passed: 0, failed: 0},
+      journey_execution_metrics: {total: 0, passed: 0, failed: 0},
+      executions: [completedExecution({running: true})],
+    };
+
+    mockGetExecutionResults
+      .mockResolvedValueOnce(pendingResults)
+      .mockResolvedValueOnce(failedExecutionResult())
+      .mockRejectedValueOnce(new Error('final fetch failed'))
+      .mockRejectedValueOnce(new Error('results unavailable for slack'));
+
+    await run(false, {executionPollIntervalMs: 0});
+
+    expect(mockedNotifySlackOnDeploymentTaskFailure).toHaveBeenCalledTimes(1);
+    expect(mockedNotifySlackOnDeploymentFailure).not.toHaveBeenCalled();
+  });
+
+  it('logs skip message on error path when SLACK_WEBHOOK_URL is unset', async () => {
+    delete process.env.SLACK_WEBHOOK_URL;
+    mockGetExecutionResults.mockRejectedValue(new Error('poll failed'));
+
+    await run(false, {executionPollIntervalMs: 0});
+
+    expect(mockedNotifySlackOnDeploymentFailure).not.toHaveBeenCalled();
+    expect(mockedNotifySlackOnDeploymentTaskFailure).not.toHaveBeenCalled();
+    expect(
+      infoSpy.mock.calls.some((call) =>
+        String(call[0]).includes('Skipping Slack notification'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/test/slackNotification.test.ts
+++ b/test/slackNotification.test.ts
@@ -1,0 +1,183 @@
+import axios from 'axios';
+import {deploymentHasFailures, formatContinueOnFailureWarning, formatDeploymentFailureMessage} from '../src/deploymentFailure';
+import {ExecutionResult} from '../src/entities/ExecutionResult';
+import {MablApiClient} from '../src/mablApiClient';
+import {
+  notifySlackOnDeploymentFailure,
+  notifySlackOnDeploymentTaskFailure,
+  resolveSlackWebhookUrl,
+} from '../src/slackNotification';
+import {escapeSlackMarkdown, fitSlackSectionText} from '../src/slackUtil';
+
+jest.mock('axios');
+jest.mock('../src/deploymentAnalysis', () => ({
+  getDeploymentFailureAnalysisForSlack: jest.fn(),
+  formatFailureAnalysisForSlack: jest.fn(),
+}));
+
+import {
+  formatFailureAnalysisForSlack,
+  getDeploymentFailureAnalysisForSlack,
+} from '../src/deploymentAnalysis';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedGetDeploymentFailureAnalysisForSlack =
+  getDeploymentFailureAnalysisForSlack as jest.MockedFunction<
+    typeof getDeploymentFailureAnalysisForSlack
+  >;
+const mockedFormatFailureAnalysisForSlack =
+  formatFailureAnalysisForSlack as jest.MockedFunction<
+    typeof formatFailureAnalysisForSlack
+  >;
+
+describe('deploymentFailure', () => {
+  it('detects plan failures without journey failures', () => {
+    const result: ExecutionResult = {
+      plan_execution_metrics: {total: 1, passed: 0, failed: 1},
+      journey_execution_metrics: {total: 0, passed: 0, failed: 0},
+      executions: [],
+    };
+
+    expect(deploymentHasFailures(result)).toBe(true);
+  });
+
+  it('formats failure message with only non-zero counts', () => {
+    expect(formatDeploymentFailureMessage(0, 1)).toBe(
+      '1 mabl plan(s) failed',
+    );
+    expect(formatDeploymentFailureMessage(2, 0)).toBe('2 mabl test(s) failed');
+    expect(formatDeploymentFailureMessage(2, 1)).toBe(
+      '2 mabl test(s) failed and 1 mabl plan(s) failed',
+    );
+  });
+
+  it('formats continue-on-failure warning with only non-zero counts', () => {
+    expect(formatContinueOnFailureWarning(0, 1)).toBe(
+      'There were 1 plan failure(s) but the continueOnPlanFailure flag is set so the task has been marked as passing',
+    );
+  });
+});
+
+describe('slackUtil', () => {
+  it('escapes markdown characters', () => {
+    expect(escapeSlackMarkdown('a & b <c>')).toBe('a &amp; b &lt;c&gt;');
+  });
+
+  it('escapes markdown formatting characters', () => {
+    const escaped = escapeSlackMarkdown('*bold* _italic_ `code` ~strike~');
+    expect(escaped).toContain('*​');
+    expect(escaped).toContain('_​');
+    expect(escaped).toContain('`​');
+    expect(escaped).toContain('~​');
+  });
+
+  it('truncates section text', () => {
+    expect(fitSlackSectionText('abcdef', 5)).toBe('ab...');
+  });
+});
+
+describe('slackNotification', () => {
+  const executionResult: ExecutionResult = {
+    plan_execution_metrics: {total: 2, passed: 1, failed: 1},
+    journey_execution_metrics: {total: 4, passed: 2, failed: 2},
+    executions: [],
+  };
+
+  const originalSlackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockedAxios.post.mockResolvedValue({status: 200});
+    mockedGetDeploymentFailureAnalysisForSlack.mockReset();
+    mockedGetDeploymentFailureAnalysisForSlack.mockResolvedValue(undefined);
+    mockedFormatFailureAnalysisForSlack.mockReset();
+    delete process.env.SLACK_WEBHOOK_URL;
+  });
+
+  afterAll(() => {
+    if (originalSlackWebhookUrl) {
+      process.env.SLACK_WEBHOOK_URL = originalSlackWebhookUrl;
+    }
+  });
+
+  it('resolveSlackWebhookUrl returns undefined when unset', () => {
+    expect(resolveSlackWebhookUrl()).toBeUndefined();
+  });
+
+  it('resolveSlackWebhookUrl trims env var', () => {
+    process.env.SLACK_WEBHOOK_URL = '  https://hooks.slack.com/test  ';
+    expect(resolveSlackWebhookUrl()).toBe('https://hooks.slack.com/test');
+  });
+
+  it('posts slack payload with deployment link and metrics', async () => {
+    const apiClient = {} as unknown as MablApiClient;
+
+    await notifySlackOnDeploymentFailure('https://hooks.slack.com/test', {
+      apiClient,
+      workspaceId: 'ws-1',
+      deploymentEventId: 'dep-1',
+      deploymentPageUrl: 'https://app.mabl.com/workspaces/ws-1/events/dep-1',
+      executionResult,
+      repository: 'mablhq/example',
+      branch: 'refs/heads/main',
+      actor: 'octocat',
+      revision: 'abc1234567890123456789012345678901234567890',
+      workflowUrl: 'https://github.com/mablhq/example/actions/runs/1',
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, payload] = mockedAxios.post.mock.calls[0] as [
+      string,
+      {text: string; blocks: object[]},
+    ];
+    expect(url).toBe('https://hooks.slack.com/test');
+    expect(payload.text).toContain('2 test failure');
+    expect(JSON.stringify(payload.blocks)).toContain(
+      'https://app.mabl.com/workspaces/ws-1/events/dep-1',
+    );
+    expect(JSON.stringify(payload.blocks)).toContain('mablhq/example');
+  });
+
+  it('includes analysis section when available', async () => {
+    mockedGetDeploymentFailureAnalysisForSlack.mockResolvedValue({
+      synopsis: 'Checkout failed',
+      summary_text: 'Payment API returned 500.',
+    });
+    mockedFormatFailureAnalysisForSlack.mockReturnValue(
+      '*Checkout failed*\n\nPayment API returned 500.',
+    );
+    const apiClient = {} as unknown as MablApiClient;
+
+    await notifySlackOnDeploymentFailure('https://hooks.slack.com/test', {
+      apiClient,
+      workspaceId: 'ws-1',
+      deploymentEventId: 'dep-1',
+      deploymentPageUrl: 'https://app.mabl.com/workspaces/ws-1/events/dep-1',
+      executionResult,
+    });
+
+    const payload = mockedAxios.post.mock.calls[0][1] as {
+      blocks: object[];
+    };
+    expect(JSON.stringify(payload.blocks)).toContain('Checkout failed');
+    expect(JSON.stringify(payload.blocks)).toContain(
+      'Payment API returned 500',
+    );
+  });
+
+  it('posts task failure payload', async () => {
+    await notifySlackOnDeploymentTaskFailure('https://hooks.slack.com/test', {
+      deploymentPageUrl: 'https://app.mabl.com/workspaces/ws-1/events/dep-1',
+      errorMessage: 'Timed out waiting for execution results',
+    });
+
+    const payload = mockedAxios.post.mock.calls[0][1] as {
+      text: string;
+      blocks: object[];
+    };
+    expect(payload.text).toContain('task failed');
+    expect(JSON.stringify(payload.blocks)).toContain(
+      'Timed out waiting for execution results',
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "importsNotUsedAsValues": "remove",
     "module": "commonjs",
+    "rootDir": ".",
     "outDir": "lib/",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Display deployment analysis in a slack message after deployment fails.
We wait to up to 20 seconds for the results - this is very likely not enough time to have the analysis, so I'll have to think of an approach that might help here - open for suggestions